### PR TITLE
ProductDocumentFactory should not attempt to create variants without price

### DIFF
--- a/src/Factory/Document/ProductDocumentFactory.php
+++ b/src/Factory/Document/ProductDocumentFactory.php
@@ -86,12 +86,14 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
         ChannelInterface $channel
     ): ProductDocument {
         /** @var ProductVariantInterface[] $productVariants */
-        $productVariants = $product->getVariants();
+        $productVariants = $product->getVariants()->filter(function (ProductVariantInterface $productVariant) use ($channel): bool {
+            return $productVariant->hasChannelPricingForChannel($channel);
+        });
 
         /**
          * @var ArrayObject
          */
-        $iterator = $product->getVariants()->getIterator();
+        $iterator = $productVariants->getIterator();
         $iterator->uasort(
             function (ProductVariantInterface $a, ProductVariantInterface $b) {
                 return $a->getName() <=> $b->getName();


### PR DESCRIPTION
Currently `ProductDocumentFactory` assumes that `ChannelPricing` exists for all `$product->getVariant()` × `$product->getChannel()` combinations. However this may not always be the case.