### PR TITLE
[FIX] not ignore gte parameter into inStock filter with range query

### DIFF
--- a/src/Filter/Widget/InStock.php
+++ b/src/Filter/Widget/InStock.php
@@ -59,6 +59,7 @@ class InStock extends AbstractRange
             $normalized[$gt] = $values[0];
         }
         if ($argumentCount === 2) {
+            $normalized[$gt] = $values[0];
             $normalized[$lt] = $values[1];
         }
 


### PR DESCRIPTION
Tests passed before fix because, into **it_shows_product_list_page_from_WEB_GB_channel_having_stock_in_given_range** exists tricky test with values **1;1**