### PR TITLE
Replaced the ONGR's collections with Doctrines ArrayCollections

### DIFF
--- a/spec/Document/ProductDocumentSpec.php
+++ b/spec/Document/ProductDocumentSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\ElasticSearchPlugin\Document;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\ElasticSearchPlugin\Document\PriceDocument;
 use Sylius\ElasticSearchPlugin\Document\ProductDocument;
@@ -70,7 +70,7 @@ final class ProductDocumentSpec extends ObjectBehavior
 
     function it_has_taxons()
     {
-        $taxons = new Collection();
+        $taxons = new ArrayCollection();
         $this->setTaxons($taxons);
 
         $this->getTaxons()->shouldReturn($taxons);
@@ -78,7 +78,7 @@ final class ProductDocumentSpec extends ObjectBehavior
 
     function it_has_attributes()
     {
-        $attributeValues = new Collection();
+        $attributeValues = new ArrayCollection();
         $this->setAttributes($attributeValues);
 
         $this->getAttributes()->shouldReturn($attributeValues);
@@ -93,7 +93,7 @@ final class ProductDocumentSpec extends ObjectBehavior
 
     function it_has_images()
     {
-        $images = new Collection();
+        $images = new ArrayCollection();
         $this->setImages($images);
 
         $this->getImages()->shouldReturn($images);

--- a/spec/Document/TaxonDocumentSpec.php
+++ b/spec/Document/TaxonDocumentSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\ElasticSearchPlugin\Document;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\ElasticSearchPlugin\Document\TaxonDocument;
 
@@ -31,7 +31,7 @@ final class TaxonDocumentSpec extends ObjectBehavior
 
     function it_has_images()
     {
-        $images = new Collection();
+        $images = new ArrayCollection();
         $this->setImages($images);
 
         $this->getImages()->shouldReturn($images);

--- a/src/Document/ProductDocument.php
+++ b/src/Document/ProductDocument.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @ElasticSearch\Document(type="product")
@@ -149,10 +150,10 @@ class ProductDocument
 
     public function __construct()
     {
-        $this->attributes = new Collection();
-        $this->taxons = new Collection();
-        $this->images = new Collection();
-        $this->variants = new Collection();
+        $this->attributes = new ArrayCollection();
+        $this->taxons = new ArrayCollection();
+        $this->images = new ArrayCollection();
+        $this->variants = new ArrayCollection();
     }
 
     /**

--- a/src/Document/TaxonDocument.php
+++ b/src/Document/TaxonDocument.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @ElasticSearch\Nested()
@@ -49,7 +50,7 @@ class TaxonDocument
 
     public function __construct()
     {
-        $this->images = new Collection();
+        $this->images = new ArrayCollection();
     }
 
     /**

--- a/src/Document/VariantDocument.php
+++ b/src/Document/VariantDocument.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @ElasticSearch\Nested
@@ -70,8 +71,8 @@ class VariantDocument
 
     public function __construct()
     {
-        $this->images = new Collection();
-        $this->options = new Collection();
+        $this->images = new ArrayCollection();
+        $this->options = new ArrayCollection();
     }
 
     /**

--- a/src/Factory/Document/ProductDocumentFactory.php
+++ b/src/Factory/Document/ProductDocumentFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
 use Doctrine\Common\Collections\Collection as DoctrineCollection;
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Ramsey\Uuid\Uuid;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
@@ -145,10 +145,10 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
         $productDocument->setCreatedAt($product->getCreatedAt());
         $productDocument->setSynchronisedAt(new \DateTime('now'));
         $productDocument->setAverageReviewRating($product->getAverageRating());
-        $productDocument->setVariants(new Collection($variantDocuments));
-        $productDocument->setImages(new Collection($imageDocuments));
-        $productDocument->setTaxons(new Collection($taxonDocuments));
-        $productDocument->setAttributes(new Collection($attributeDocuments));
+        $productDocument->setVariants(new ArrayCollection($variantDocuments));
+        $productDocument->setImages(new ArrayCollection($imageDocuments));
+        $productDocument->setTaxons(new ArrayCollection($taxonDocuments));
+        $productDocument->setAttributes(new ArrayCollection($attributeDocuments));
 
         /**
          * Set smallest product variant price, used for search by price

--- a/src/Factory/Document/TaxonDocumentFactory.php
+++ b/src/Factory/Document/TaxonDocumentFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
@@ -54,7 +54,7 @@ final class TaxonDocumentFactory implements TaxonDocumentFactoryInterface
         foreach ($taxon->getImages() as $image) {
             $images[] = $this->imageDocumentFactory->create($image);
         }
-        $taxonDocument->setImages(new Collection($images));
+        $taxonDocument->setImages(new ArrayCollection($images));
 
         return $taxonDocument;
     }

--- a/src/Factory/View/ProductListViewFactory.php
+++ b/src/Factory/View/ProductListViewFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\ElasticSearchPlugin\Factory\View;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\Collection;
 use ONGR\FilterManagerBundle\Search\SearchResponse;
 use Sylius\ElasticSearchPlugin\Controller\AttributeView;
 use Sylius\ElasticSearchPlugin\Controller\ImageView;

--- a/tests/Factory/ProductDocumentFactoryTest.php
+++ b/tests/Factory/ProductDocumentFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\ElasticSearchPlugin\Factory;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Bundle\ChannelBundle\Doctrine\ORM\ChannelRepository;
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\ProductRepository;
 use Sylius\Component\Core\Model\Channel;
@@ -106,7 +106,7 @@ final class ProductDocumentFactoryTest extends KernelTestCase
         $this->assertEquals($product->getCode(), $product->getCode());
         $this->assertEquals($product->getName(), $product->getName());
         $this->assertEquals('en_GB', $product->getLocaleCode());
-        $this->assertEquals(new Collection($productAttributes), $product->getAttributes());
+        $this->assertEquals(new ArrayCollection($productAttributes), $product->getAttributes());
         $this->assertEquals(1000, $product->getPrice()->getAmount());
         $this->assertEquals('GBP', $product->getPrice()->getCurrency());
         $this->assertEquals('en_GB', $product->getLocaleCode());
@@ -116,7 +116,7 @@ final class ProductDocumentFactoryTest extends KernelTestCase
         $this->assertEquals($createdAt, $product->getCreatedAt());
         $this->assertEquals('Logan Mug', $product->getDescription());
         $this->assertEquals($taxon, $product->getMainTaxon());
-        $this->assertEquals(new Collection($productTaxons), $product->getTaxons());
+        $this->assertEquals(new ArrayCollection($productTaxons), $product->getTaxons());
         $this->assertEquals(0.0, $product->getAverageReviewRating());
     }
 
@@ -170,7 +170,7 @@ final class ProductDocumentFactoryTest extends KernelTestCase
         $this->assertEquals($product->getName(), $product->getName());
         $this->assertEquals('en_GB', $product->getLocaleCode());
         $this->assertEquals(
-            new Collection([$productAttribute]),
+            new ArrayCollection([$productAttribute]),
             $product->getAttributes()
         );
         $this->assertEquals(1000, $product->getPrice()->getAmount());
@@ -182,7 +182,7 @@ final class ProductDocumentFactoryTest extends KernelTestCase
         $this->assertEquals($createdAt, $product->getCreatedAt());
         $this->assertEquals('Logan Mug', $product->getDescription());
         $this->assertEquals($taxon, $product->getMainTaxon());
-        $this->assertEquals(new Collection($productTaxons), $product->getTaxons());
+        $this->assertEquals(new ArrayCollection($productTaxons), $product->getTaxons());
         $this->assertEquals(0.0, $product->getAverageReviewRating());
     }
 


### PR DESCRIPTION
The class `ONGR\ElasticsearchBundle\Collection` is deprecated and should be replaced with the doctrine's `ArrayCollection`s.