### PR TITLE
Fix document type hinting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,9 @@
     "require": {
         "php": "^7.1",
         "sylius/sylius": "^1.0",
-        "ongr/elasticsearch-dsl": "^5.0",
-        "ongr/elasticsearch-bundle": "^5.0",
+        "ongr/elasticsearch-bundle": "dev-6.0-dev",
         "simple-bus/symfony-bridge": "^4.1",
-        "ongr/filter-manager-bundle": "2.1.x-dev as v2.1.1",
+        "ongr/filter-manager-bundle": "dev-es-6.0",
         "ramsey/uuid": "^3.7"
     },
     "require-dev": {

--- a/src/Document/AttributeDocument.php
+++ b/src/Document/AttributeDocument.php
@@ -7,7 +7,7 @@ namespace Sylius\ElasticSearchPlugin\Document;
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
 
 /**
- * @ElasticSearch\Nested
+ * @ElasticSearch\NestedType
  */
 class AttributeDocument
 {

--- a/src/Document/AttributeDocument.php
+++ b/src/Document/AttributeDocument.php
@@ -9,7 +9,7 @@ use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
 /**
  * @ElasticSearch\NestedType
  */
-class AttributeDocument
+class AttributeDocument implements AttributeDocumentInterface
 {
     /**
      * @var string

--- a/src/Document/AttributeDocumentInterface.php
+++ b/src/Document/AttributeDocumentInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ElasticSearchPlugin\Document;
+
+interface AttributeDocumentInterface
+{
+    /**
+     * @return string
+     */
+    public function getCode(): string;
+
+    /**
+     * @param string $code
+     */
+    public function setCode(string $code): void;
+
+    /**
+     * @return string
+     */
+    public function getName(): ?string;
+
+    /**
+     * @param string $name
+     */
+    public function setName(?string $name): void;
+
+    /**
+     * @return mixed
+     */
+    public function getValue();
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue($value): void;
+}

--- a/src/Document/ImageDocument.php
+++ b/src/Document/ImageDocument.php
@@ -9,7 +9,7 @@ use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
 /**
  * @ElasticSearch\ObjectType
  */
-class ImageDocument
+class ImageDocument implements ImageDocumentInterface
 {
     /**
      * @var string

--- a/src/Document/ImageDocument.php
+++ b/src/Document/ImageDocument.php
@@ -7,7 +7,7 @@ namespace Sylius\ElasticSearchPlugin\Document;
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
 
 /**
- * @ElasticSearch\Object
+ * @ElasticSearch\ObjectType
  */
 class ImageDocument
 {

--- a/src/Document/ImageDocumentInterface.php
+++ b/src/Document/ImageDocumentInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ElasticSearchPlugin\Document;
+
+interface ImageDocumentInterface
+{
+    /**
+     * @return string
+     */
+    public function getCode(): ?string;
+
+    /**
+     * @param string $code
+     */
+    public function setCode(?string $code): void;
+
+    /**
+     * @return string
+     */
+    public function getPath(): string;
+
+    /**
+     * @param string $path
+     */
+    public function setPath(string $path): void;
+}

--- a/src/Document/OptionDocument.php
+++ b/src/Document/OptionDocument.php
@@ -7,7 +7,7 @@ namespace Sylius\ElasticSearchPlugin\Document;
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
 
 /**
- * @ElasticSearch\Nested
+ * @ElasticSearch\NestedType
  */
 class OptionDocument
 {

--- a/src/Document/OptionDocument.php
+++ b/src/Document/OptionDocument.php
@@ -9,7 +9,7 @@ use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
 /**
  * @ElasticSearch\NestedType
  */
-class OptionDocument
+class OptionDocument implements OptionDocumentInterface
 {
     /**
      * @var string

--- a/src/Document/OptionDocumentInterface.php
+++ b/src/Document/OptionDocumentInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ElasticSearchPlugin\Document;
+
+interface OptionDocumentInterface
+{
+    /**
+     * @return string
+     */
+    public function getCode(): string;
+
+    /**
+     * @param string $code
+     */
+    public function setCode(string $code): void;
+
+    /**
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * @param string $name
+     */
+    public function setName(string $name): void;
+
+    /**
+     * @return string
+     */
+    public function getValue(): string;
+
+    /**
+     * @param string $value
+     */
+    public function setValue(string $value): void;
+}

--- a/src/Document/PriceDocument.php
+++ b/src/Document/PriceDocument.php
@@ -7,7 +7,7 @@ namespace Sylius\ElasticSearchPlugin\Document;
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
 
 /**
- * @ElasticSearch\Object
+ * @ElasticSearch\ObjectType
  */
 class PriceDocument
 {

--- a/src/Document/PriceDocument.php
+++ b/src/Document/PriceDocument.php
@@ -9,7 +9,7 @@ use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
 /**
  * @ElasticSearch\ObjectType
  */
-class PriceDocument
+class PriceDocument implements PriceDocumentInterface
 {
     /**
      * @var int
@@ -43,7 +43,7 @@ class PriceDocument
     /**
      * @param int $amount
      */
-    public function setAmount(int $amount): void
+    public function setAmount($amount): void
     {
         $this->amount = $amount;
     }

--- a/src/Document/PriceDocumentInterface.php
+++ b/src/Document/PriceDocumentInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ElasticSearchPlugin\Document;
+
+interface PriceDocumentInterface
+{
+    /**
+     * @return int
+     */
+    public function getAmount();
+
+    /**
+     * @param int $amount
+     */
+    public function setAmount($amount): void;
+
+    /**
+     * @return int
+     */
+    public function getOriginalAmount(): int;
+
+    /**
+     * @param int $originalAmount
+     */
+    public function setOriginalAmount(int $originalAmount = 0): void;
+
+    /**
+     * @return string
+     */
+    public function getCurrency(): string;
+
+    /**
+     * @param string $currency
+     */
+    public function setCurrency(string $currency): void;
+}

--- a/src/Document/ProductDocument.php
+++ b/src/Document/ProductDocument.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 /**
  * @ElasticSearch\Document(type="product")
@@ -101,21 +102,21 @@ class ProductDocument
     protected $mainTaxon;
 
     /**
-     * @var Collection|TaxonDocument[]
+     * @var ArrayCollection|TaxonDocument[]
      *
      * @ElasticSearch\Embedded(class="Sylius\ElasticSearchPlugin\Document\TaxonDocument", multiple=true)
      */
     protected $taxons;
 
     /**
-     * @var Collection
+     * @var ArrayCollection|AttributeDocument[]
      *
      * @ElasticSearch\Embedded(class="Sylius\ElasticSearchPlugin\Document\AttributeDocument", multiple=true)
      */
     protected $attributes;
 
     /**
-     * @var Collection
+     * @var ArrayCollection|ImageDocument[]
      *
      * @ElasticSearch\Embedded(class="Sylius\ElasticSearchPlugin\Document\ImageDocument", multiple=true)
      */
@@ -134,7 +135,7 @@ class ProductDocument
     protected $createdAt;
 
     /**
-     * @var Collection
+     * @var ArrayCollection|VariantDocument[]
      *
      * @ElasticSearch\Embedded(class="Sylius\ElasticSearchPlugin\Document\VariantDocument", multiple=true)
      */
@@ -149,10 +150,10 @@ class ProductDocument
 
     public function __construct()
     {
-        $this->attributes = new Collection();
-        $this->taxons = new Collection();
-        $this->images = new Collection();
-        $this->variants = new Collection();
+        $this->attributes = new ArrayCollection();
+        $this->taxons = new ArrayCollection();
+        $this->images = new ArrayCollection();
+        $this->variants = new ArrayCollection();
     }
 
     /**
@@ -342,13 +343,13 @@ class ProductDocument
     /**
      * @param Collection|TaxonDocument[] $taxons
      */
-    public function setTaxons($taxons): void
+    public function setTaxons(Collection $taxons): void
     {
         $this->taxons = $taxons;
     }
 
     /**
-     * @return Collection
+     * @return Collection|AttributeDocument[]
      */
     public function getAttributes(): Collection
     {
@@ -364,7 +365,7 @@ class ProductDocument
     }
 
     /**
-     * @return Collection
+     * @return Collection|ImageDocument[]
      */
     public function getImages(): Collection
     {
@@ -428,7 +429,7 @@ class ProductDocument
     }
 
     /**
-     * @return Collection
+     * @return Collection|VariantDocument[]
      */
     public function getVariants(): Collection
     {

--- a/src/Document/ProductDocument.php
+++ b/src/Document/ProductDocument.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Collections\Collection;
 /**
  * @ElasticSearch\Document(type="product")
  */
-class ProductDocument
+class ProductDocument implements ProductDocumentInterface
 {
     /**
      * @var string
@@ -301,39 +301,39 @@ class ProductDocument
     }
 
     /**
-     * @return PriceDocument
+     * @return PriceDocumentInterface
      */
-    public function getPrice(): PriceDocument
+    public function getPrice(): PriceDocumentInterface
     {
         return $this->price;
     }
 
     /**
-     * @param PriceDocument $price
+     * @param PriceDocumentInterface $price
      */
-    public function setPrice(PriceDocument $price): void
+    public function setPrice(PriceDocumentInterface $price): void
     {
         $this->price = $price;
     }
 
     /**
-     * @return TaxonDocument
+     * @return TaxonDocumentInterface
      */
-    public function getMainTaxon(): ?TaxonDocument
+    public function getMainTaxon(): ?TaxonDocumentInterface
     {
         return $this->mainTaxon;
     }
 
     /**
-     * @param TaxonDocument $mainTaxon
+     * @param TaxonDocumentInterface $mainTaxon
      */
-    public function setMainTaxon(TaxonDocument $mainTaxon): void
+    public function setMainTaxon(TaxonDocumentInterface $mainTaxon): void
     {
         $this->mainTaxon = $mainTaxon;
     }
 
     /**
-     * @return Collection|TaxonDocument[]
+     * @return Collection|TaxonDocumentInterface[]
      */
     public function getTaxons(): Collection
     {
@@ -341,7 +341,7 @@ class ProductDocument
     }
 
     /**
-     * @param Collection|TaxonDocument[] $taxons
+     * @param Collection|TaxonDocumentInterface[] $taxons
      */
     public function setTaxons(Collection $taxons): void
     {
@@ -349,7 +349,7 @@ class ProductDocument
     }
 
     /**
-     * @return Collection|AttributeDocument[]
+     * @return Collection|AttributeDocumentInterface[]
      */
     public function getAttributes(): Collection
     {
@@ -365,7 +365,7 @@ class ProductDocument
     }
 
     /**
-     * @return Collection|ImageDocument[]
+     * @return Collection|ImageDocumentInterface[]
      */
     public function getImages(): Collection
     {
@@ -429,7 +429,7 @@ class ProductDocument
     }
 
     /**
-     * @return Collection|VariantDocument[]
+     * @return Collection|VariantDocumentInterface[]
      */
     public function getVariants(): Collection
     {

--- a/src/Document/ProductDocumentInterface.php
+++ b/src/Document/ProductDocumentInterface.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ElasticSearchPlugin\Document;
+
+use Doctrine\Common\Collections\Collection;
+
+interface  ProductDocumentInterface
+{
+    /**
+     * @return string
+     */
+    public function getUuid(): string;
+
+    /**
+     * @param string $uuid
+     */
+    public function setUuid(string $uuid): void;
+
+    /**
+     * @return mixed
+     */
+    public function getId();
+
+    /**
+     * @param mixed $id
+     */
+    public function setId($id): void;
+
+    /**
+     * @return string
+     */
+    public function getCode(): string;
+
+    /**
+     * @param string $code
+     */
+    public function setCode(string $code): void;
+
+    /**
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * @param string $name
+     */
+    public function setName(string $name): void;
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool;
+
+    /**
+     * @param bool $enabled
+     */
+    public function setEnabled(bool $enabled): void;
+
+    /**
+     * @return string
+     */
+    public function getSlug(): string;
+
+    /**
+     * @param string $slug
+     */
+    public function setSlug(string $slug): void;
+
+    /**
+     * @return string
+     */
+    public function getChannelCode(): string;
+
+    /**
+     * @param string $channelCode
+     */
+    public function setChannelCode(string $channelCode): void;
+
+    /**
+     * @return string
+     */
+    public function getLocaleCode(): string;
+
+    /**
+     * @param string $localeCode
+     */
+    public function setLocaleCode(string $localeCode): void;
+
+    /**
+     * @return string
+     */
+    public function getDescription(): ?string;
+
+    /**
+     * @param string $description
+     */
+    public function setDescription(?string $description): void;
+
+    /**
+     * @return PriceDocument
+     */
+    public function getPrice(): PriceDocumentInterface;
+
+    /**
+     * @param PriceDocumentInterface $price
+     */
+    public function setPrice(PriceDocumentInterface $price): void;
+
+    /**
+     * @return TaxonDocumentInterface
+     */
+    public function getMainTaxon(): ?TaxonDocumentInterface;
+
+    /**
+     * @param TaxonDocumentInterface $mainTaxon
+     */
+    public function setMainTaxon(TaxonDocumentInterface $mainTaxon): void;
+
+    /**
+     * @return Collection|TaxonDocumentInterface[]
+     */
+    public function getTaxons(): Collection;
+
+    /**
+     * @param Collection|TaxonDocument[] $taxons
+     */
+    public function setTaxons(Collection $taxons): void;
+
+    /**
+     * @return Collection|AttributeDocumentInterface[]
+     */
+    public function getAttributes(): Collection;
+
+    /**
+     * @param Collection $attributes
+     */
+    public function setAttributes(Collection $attributes): void;
+
+    /**
+     * @return Collection|ImageDocumentInterface[]
+     */
+    public function getImages(): Collection;
+
+    /**
+     * @param Collection $images
+     */
+    public function setImages(Collection $images): void;
+
+    /**
+     * @return float
+     */
+    public function getAverageReviewRating(): ?float;
+
+    /**
+     * @param float $averageReviewRating
+     */
+    public function setAverageReviewRating(float $averageReviewRating): void;
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCreatedAt(): \DateTimeInterface;
+
+    /**
+     * @param \DateTimeInterface $createdAt
+     */
+    public function setCreatedAt(\DateTimeInterface $createdAt): void;
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getSynchronisedAt(): \DateTimeInterface;
+
+    /**
+     * @param \DateTimeInterface $synchronisedAt
+     */
+    public function setSynchronisedAt(\DateTimeInterface $synchronisedAt): void;
+
+    /**
+     * @return Collection|VariantDocumentInterface[]
+     */
+    public function getVariants(): Collection;
+
+    /**
+     * @param Collection $variants
+     */
+    public function setVariants(Collection $variants): void;
+}

--- a/src/Document/TaxonDocument.php
+++ b/src/Document/TaxonDocument.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @ElasticSearch\Nested()
@@ -49,7 +50,7 @@ class TaxonDocument
 
     public function __construct()
     {
-        $this->images = new Collection();
+        $this->images = new ArrayCollection();
     }
 
     /**

--- a/src/Document/TaxonDocument.php
+++ b/src/Document/TaxonDocument.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * @ElasticSearch\Nested()
+ * @ElasticSearch\NestedType
  */
 class TaxonDocument
 {

--- a/src/Document/TaxonDocument.php
+++ b/src/Document/TaxonDocument.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 /**
  * @ElasticSearch\NestedType
  */
-class TaxonDocument
+class TaxonDocument implements TaxonDocumentInterface
 {
     /**
      * @var string

--- a/src/Document/TaxonDocumentInterface.php
+++ b/src/Document/TaxonDocumentInterface.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ElasticSearchPlugin\Document;
+
+use Doctrine\Common\Collections\Collection;
+
+interface TaxonDocumentInterface
+{
+    /**
+     * @return string
+     */
+    public function getCode(): string;
+
+    /**
+     * @param string $code
+     */
+    public function setCode(string $code): void;
+
+    /**
+     * @return string
+     */
+    public function getSlug(): string;
+
+    /**
+     * @param string $slug
+     */
+    public function setSlug(string $slug): void;
+
+    /**
+     * @return int
+     */
+    public function getPosition(): int;
+
+    /**
+     * @param int $position
+     */
+    public function setPosition(int $position): void;
+
+    /**
+     * @return Collection
+     */
+    public function getImages(): Collection;
+
+    /**
+     * @param Collection $images
+     */
+    public function setImages(Collection $images): void;
+
+    /**
+     * @return string|null
+     */
+    public function getDescription(): ?string;
+
+    /**
+     * @param string|null $description
+     */
+    public function setDescription(?string $description): void;
+}

--- a/src/Document/VariantDocument.php
+++ b/src/Document/VariantDocument.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ElasticSearch;
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @ElasticSearch\Nested
@@ -62,7 +63,7 @@ class VariantDocument
     protected $isTracked;
 
     /**
-     * @var Collection
+     * @var Collection|OptionDocument[]
      *
      * @ElasticSearch\Embedded(class="Sylius\ElasticSearchPlugin\Document\OptionDocument", multiple=true)
      */
@@ -70,8 +71,8 @@ class VariantDocument
 
     public function __construct()
     {
-        $this->images = new Collection();
-        $this->options = new Collection();
+        $this->images = new ArrayCollection();
+        $this->options = new ArrayCollection();
     }
 
     /**
@@ -192,7 +193,7 @@ class VariantDocument
     }
 
     /**
-     * @return Collection
+     * @return Collection|OptionDocument[]
      */
     public function getOptions(): Collection
     {

--- a/src/Document/VariantDocument.php
+++ b/src/Document/VariantDocument.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * @ElasticSearch\Nested
+ * @ElasticSearch\NestedType
  */
 class VariantDocument
 {

--- a/src/Document/VariantDocument.php
+++ b/src/Document/VariantDocument.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 /**
  * @ElasticSearch\NestedType
  */
-class VariantDocument
+class VariantDocument implements VariantDocumentInterface
 {
     /**
      * @var mixed
@@ -28,7 +28,7 @@ class VariantDocument
     protected $images;
 
     /**
-     * @var PriceDocument
+     * @var PriceDocumentInterface
      *
      * @ElasticSearch\Embedded(class="Sylius\ElasticSearchPlugin\Document\PriceDocument")
      */
@@ -108,17 +108,17 @@ class VariantDocument
     }
 
     /**
-     * @return PriceDocument
+     * @return PriceDocumentInterface
      */
-    public function getPrice(): PriceDocument
+    public function getPrice(): PriceDocumentInterface
     {
         return $this->price;
     }
 
     /**
-     * @param PriceDocument $price
+     * @param PriceDocumentInterface $price
      */
-    public function setPrice(PriceDocument $price): void
+    public function setPrice(PriceDocumentInterface $price): void
     {
         $this->price = $price;
     }

--- a/src/Document/VariantDocumentInterface.php
+++ b/src/Document/VariantDocumentInterface.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ElasticSearchPlugin\Document;
+
+use Doctrine\Common\Collections\Collection;
+
+interface VariantDocumentInterface
+{
+    /**
+     * @return mixed
+     */
+    public function getId();
+
+    /**
+     * @param mixed $id
+     */
+    public function setId($id): void;
+
+    /**
+     * @return Collection
+     */
+    public function getImages(): Collection;
+
+    /**
+     * @param Collection $images
+     */
+    public function setImages(Collection $images): void;
+
+    /**
+     * @return PriceDocumentInterface
+     */
+    public function getPrice(): PriceDocumentInterface;
+
+    /**
+     * @param PriceDocumentInterface $price
+     */
+    public function setPrice(PriceDocumentInterface $price): void;
+
+    /**
+     * @return string
+     */
+    public function getCode(): string;
+
+    /**
+     * @param string $code
+     */
+    public function setCode(string $code): void;
+
+    /**
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * @param string $name
+     */
+    public function setName(string $name): void;
+
+    /**
+     * @return int
+     */
+    public function getStock(): int;
+
+    /**
+     * @param int $stock
+     */
+    public function setStock(int $stock): void;
+
+    /**
+     * @return bool
+     */
+    public function getIsTracked(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isTracked(): bool;
+
+    /**
+     * @param bool $isTracked
+     */
+    public function setIsTracked(bool $isTracked): void;
+
+    /**
+     * @return Collection|OptionDocumentInterface[]
+     */
+    public function getOptions(): Collection;
+
+    /**
+     * @param Collection $options
+     */
+    public function setOptions(Collection $options): void;
+}

--- a/src/Factory/Document/AttributeDocumentFactory.php
+++ b/src/Factory/Document/AttributeDocumentFactory.php
@@ -7,7 +7,7 @@ namespace Sylius\ElasticSearchPlugin\Factory\Document;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Product\Model\ProductAttributeTranslationInterface;
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
-use Sylius\ElasticSearchPlugin\Document\AttributeDocument;
+use Sylius\ElasticSearchPlugin\Document\AttributeDocumentInterface;
 
 final class AttributeDocumentFactory implements AttributeDocumentFactoryInterface
 {
@@ -38,7 +38,7 @@ final class AttributeDocumentFactory implements AttributeDocumentFactoryInterfac
                 );
             }
         } else {
-            /** @var AttributeDocument $productAttribute */
+            /** @var AttributeDocumentInterface $productAttribute */
             $productAttribute = new $this->attributeDocumentClass();
             $productAttribute->setCode($productAttributeValue->getCode());
             $productAttribute->setValue($data);

--- a/src/Factory/Document/ImageDocumentFactory.php
+++ b/src/Factory/Document/ImageDocumentFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
 use Sylius\Component\Core\Model\ImageInterface;
-use Sylius\ElasticSearchPlugin\Document\ImageDocument;
+use Sylius\ElasticSearchPlugin\Document\ImageDocumentInterface;
 
 final class ImageDocumentFactory implements ImageDocumentFactoryInterface
 {
@@ -17,9 +17,9 @@ final class ImageDocumentFactory implements ImageDocumentFactoryInterface
         $this->imageDocumentClass = $imageDocumentClass;
     }
 
-    public function create(ImageInterface $image): ImageDocument
+    public function create(ImageInterface $image): ImageDocumentInterface
     {
-        /** @var ImageDocument $imageDocument */
+        /** @var ImageDocumentInterface $imageDocument */
         $imageDocument = new $this->imageDocumentClass();
         $imageDocument->setCode($image->getType());
         $imageDocument->setPath($image->getPath());

--- a/src/Factory/Document/ImageDocumentFactoryInterface.php
+++ b/src/Factory/Document/ImageDocumentFactoryInterface.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
 use Sylius\Component\Core\Model\ImageInterface;
-use Sylius\ElasticSearchPlugin\Document\ImageDocument;
+use Sylius\ElasticSearchPlugin\Document\ImageDocumentInterface;
 
 interface ImageDocumentFactoryInterface
 {
-    public function create(ImageInterface $image): ImageDocument;
+    public function create(ImageInterface $image): ImageDocumentInterface;
 }

--- a/src/Factory/Document/OptionDocumentFactory.php
+++ b/src/Factory/Document/OptionDocumentFactory.php
@@ -8,7 +8,7 @@ use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Product\Model\ProductOptionTranslationInterface;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
 use Sylius\Component\Product\Model\ProductOptionValueTranslationInterface;
-use Sylius\ElasticSearchPlugin\Document\OptionDocument;
+use Sylius\ElasticSearchPlugin\Document\OptionDocumentInterface;
 
 final class OptionDocumentFactory implements OptionDocumentFactoryInterface
 {
@@ -23,14 +23,14 @@ final class OptionDocumentFactory implements OptionDocumentFactoryInterface
     public function create(
         ProductOptionValueInterface $optionValue,
         LocaleInterface $locale
-    ): OptionDocument {
+    ): OptionDocumentInterface {
         /** @var ProductOptionValueTranslationInterface $optionValueTranslation */
         $optionValueTranslation = $optionValue->getTranslation($locale->getCode());
 
         /** @var ProductOptionTranslationInterface $productOptionTranslation */
         $productOptionTranslation = $optionValue->getOption()->getTranslation($locale->getCode());
 
-        /** @var OptionDocument $option */
+        /** @var OptionDocumentInterface $option */
         $option = new $this->optionDocumentClass();
         $option->setCode($optionValue->getOptionCode());
         $option->setName($productOptionTranslation->getName());

--- a/src/Factory/Document/OptionDocumentFactoryInterface.php
+++ b/src/Factory/Document/OptionDocumentFactoryInterface.php
@@ -6,12 +6,12 @@ namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
-use Sylius\ElasticSearchPlugin\Document\OptionDocument;
+use Sylius\ElasticSearchPlugin\Document\OptionDocumentInterface;
 
 interface OptionDocumentFactoryInterface
 {
     public function create(
         ProductOptionValueInterface $optionValue,
         LocaleInterface $locale
-    ): OptionDocument;
+    ): OptionDocumentInterface;
 }

--- a/src/Factory/Document/PriceDocumentFactory.php
+++ b/src/Factory/Document/PriceDocumentFactory.php
@@ -6,7 +6,7 @@ namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
-use Sylius\ElasticSearchPlugin\Document\PriceDocument;
+use Sylius\ElasticSearchPlugin\Document\PriceDocumentInterface;
 
 final class PriceDocumentFactory implements PriceDocumentFactoryInterface
 {
@@ -23,8 +23,8 @@ final class PriceDocumentFactory implements PriceDocumentFactoryInterface
     public function create(
         ChannelPricingInterface $channelPricing,
         CurrencyInterface $currency
-    ): PriceDocument {
-        /** @var PriceDocument $price */
+    ): PriceDocumentInterface {
+        /** @var PriceDocumentInterface $price */
         $price = new $this->priceDocumentClass();
         $originalAmount = $channelPricing->getOriginalPrice();
 

--- a/src/Factory/Document/PriceDocumentFactoryInterface.php
+++ b/src/Factory/Document/PriceDocumentFactoryInterface.php
@@ -6,12 +6,12 @@ namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
-use Sylius\ElasticSearchPlugin\Document\PriceDocument;
+use Sylius\ElasticSearchPlugin\Document\PriceDocumentInterface;
 
 interface PriceDocumentFactoryInterface
 {
     public function create(
         ChannelPricingInterface $channelPricing,
         CurrencyInterface $currency
-    ): PriceDocument;
+    ): PriceDocumentInterface;
 }

--- a/src/Factory/Document/ProductDocumentFactory.php
+++ b/src/Factory/Document/ProductDocumentFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
-use Doctrine\Common\Collections\Collection as DoctrineCollection;
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Ramsey\Uuid\Uuid;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
@@ -145,10 +145,10 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
         $productDocument->setCreatedAt($product->getCreatedAt());
         $productDocument->setSynchronisedAt(new \DateTime('now'));
         $productDocument->setAverageReviewRating($product->getAverageRating());
-        $productDocument->setVariants(new Collection($variantDocuments));
-        $productDocument->setImages(new Collection($imageDocuments));
-        $productDocument->setTaxons(new Collection($taxonDocuments));
-        $productDocument->setAttributes(new Collection($attributeDocuments));
+        $productDocument->setVariants(new ArrayCollection($variantDocuments));
+        $productDocument->setImages(new ArrayCollection($imageDocuments));
+        $productDocument->setTaxons(new ArrayCollection($taxonDocuments));
+        $productDocument->setAttributes(new ArrayCollection($attributeDocuments));
 
         /**
          * Set smallest product variant price, used for search by price
@@ -170,7 +170,7 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
     }
 
     /**
-     * @param ProductVariantInterface[]|DoctrineCollection $variants
+     * @param ProductVariantInterface[]|Collection $variants
      * @param ChannelInterface $channel
      *
      * @return ChannelPricingInterface

--- a/src/Factory/Document/ProductDocumentFactory.php
+++ b/src/Factory/Document/ProductDocumentFactory.php
@@ -14,9 +14,9 @@ use Sylius\Component\Core\Model\ProductTranslationInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Model\TranslationInterface;
-use Sylius\ElasticSearchPlugin\Document\ImageDocument;
-use Sylius\ElasticSearchPlugin\Document\ProductDocument;
-use Sylius\ElasticSearchPlugin\Document\TaxonDocument;
+use Sylius\ElasticSearchPlugin\Document\ImageDocumentInterface;
+use Sylius\ElasticSearchPlugin\Document\ProductDocumentInterface;
+use Sylius\ElasticSearchPlugin\Document\TaxonDocumentInterface;
 use Zend\Stdlib\ArrayObject;
 
 final class ProductDocumentFactory implements ProductDocumentFactoryInterface
@@ -60,7 +60,7 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
         VariantDocumentFactoryInterface $variantDocumentFactory,
         array $attributeWhitelist
     ) {
-        $this->assertClassExtends($productDocumentClass, ProductDocument::class);
+        $this->assertClassImplements($productDocumentClass, ProductDocumentInterface::class);
         $this->productDocumentClass = $productDocumentClass;
 
         $this->attributeDocumentFactory = $attributeDocumentFactory;
@@ -78,13 +78,13 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
      * @param LocaleInterface $locale
      * @param ChannelInterface $channel
      *
-     * @return ProductDocument
+     * @return ProductDocumentInterface
      */
     public function create(
         ProductInterface $product,
         LocaleInterface $locale,
         ChannelInterface $channel
-    ): ProductDocument {
+    ): ProductDocumentInterface {
         /** @var ProductVariantInterface[] $productVariants */
         $productVariants = $product->getVariants()->filter(function (ProductVariantInterface $productVariant) use ($channel): bool {
             return $productVariant->hasChannelPricingForChannel($channel);
@@ -104,7 +104,7 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
             $variantDocuments[] = $this->variantDocumentFactory->create($variant, $channel, $locale);
         }
 
-        /** @var ImageDocument[] $imageDocuments */
+        /** @var ImageDocumentInterface[] $imageDocuments */
         $imageDocuments = [];
         foreach ($product->getImages() as $productImage) {
             foreach ($productVariants as $variant) {
@@ -116,7 +116,7 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
             $imageDocuments[] = $this->imageDocumentFactory->create($productImage);
         }
 
-        /** @var TaxonDocument[] $taxonDocuments */
+        /** @var TaxonDocumentInterface[] $taxonDocuments */
         $taxonDocuments = [];
         foreach ($product->getProductTaxons() as $syliusProductTaxon) {
             $taxonDocuments[] = $this->taxonDocumentFactory->create(
@@ -131,7 +131,7 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
 
         $attributeDocuments = $this->getAttributeDocuments($product, $locale, $channel);
 
-        /** @var ProductDocument $productDocument */
+        /** @var ProductDocumentInterface $productDocument */
         $productDocument = new $this->productDocumentClass();
         $productDocument->setUuid(Uuid::uuid4()->toString());
         $productDocument->setId($product->getId());
@@ -200,10 +200,10 @@ final class ProductDocumentFactory implements ProductDocumentFactoryInterface
      *
      * @throws \InvalidArgumentException
      */
-    private function assertClassExtends(string $class, string $parentClass)
+    private function assertClassImplements(string $class, string $parentClass)
     {
-        if ($class !== $parentClass && !in_array($parentClass, class_parents($class), true)) {
-            throw new \InvalidArgumentException(sprintf('Class %s MUST extend class %s!', $class, $parentClass));
+        if ($class instanceof $parentClass) {
+            throw new \InvalidArgumentException(sprintf('Class %s MUST implement class %s!', $class, $parentClass));
         }
     }
 

--- a/src/Factory/Document/ProductDocumentFactoryInterface.php
+++ b/src/Factory/Document/ProductDocumentFactoryInterface.php
@@ -7,7 +7,7 @@ namespace Sylius\ElasticSearchPlugin\Factory\Document;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
-use Sylius\ElasticSearchPlugin\Document\ProductDocument;
+use Sylius\ElasticSearchPlugin\Document\ProductDocumentInterface;
 
 interface ProductDocumentFactoryInterface
 {
@@ -16,11 +16,11 @@ interface ProductDocumentFactoryInterface
      * @param LocaleInterface $locale
      * @param ChannelInterface $channel
      *
-     * @return ProductDocument
+     * @return ProductDocumentInterface
      */
     public function create(
         ProductInterface $product,
         LocaleInterface $locale,
         ChannelInterface $channel
-    ): ProductDocument;
+    ): ProductDocumentInterface;
 }

--- a/src/Factory/Document/TaxonDocumentFactory.php
+++ b/src/Factory/Document/TaxonDocumentFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
@@ -54,7 +54,7 @@ final class TaxonDocumentFactory implements TaxonDocumentFactoryInterface
         foreach ($taxon->getImages() as $image) {
             $images[] = $this->imageDocumentFactory->create($image);
         }
-        $taxonDocument->setImages(new Collection($images));
+        $taxonDocument->setImages(new ArrayCollection($images));
 
         return $taxonDocument;
     }

--- a/src/Factory/Document/TaxonDocumentFactory.php
+++ b/src/Factory/Document/TaxonDocumentFactory.php
@@ -8,8 +8,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
-use Sylius\ElasticSearchPlugin\Document\ImageDocument;
-use Sylius\ElasticSearchPlugin\Document\TaxonDocument;
+use Sylius\ElasticSearchPlugin\Document\ImageDocumentInterface;
+use Sylius\ElasticSearchPlugin\Document\TaxonDocumentInterface;
 
 final class TaxonDocumentFactory implements TaxonDocumentFactoryInterface
 {
@@ -30,14 +30,14 @@ final class TaxonDocumentFactory implements TaxonDocumentFactoryInterface
      * @param LocaleInterface $localeCode
      * @param int|null $position Override the position in the Taxon model by passing your own
      *
-     * @return TaxonDocument
+     * @return TaxonDocumentInterface
      */
-    public function create(TaxonInterface $taxon, LocaleInterface $localeCode, ?int $position = null): TaxonDocument
+    public function create(TaxonInterface $taxon, LocaleInterface $localeCode, ?int $position = null): TaxonDocumentInterface
     {
         /** @var TaxonTranslationInterface $taxonTranslation */
         $taxonTranslation = $taxon->getTranslation($localeCode->getCode());
 
-        /** @var TaxonDocument $taxonDocument */
+        /** @var TaxonDocumentInterface $taxonDocument */
         $taxonDocument = new $this->taxonDocumentClass();
         $taxonDocument->setCode($taxon->getCode());
         $taxonDocument->setSlug($taxonTranslation->getSlug());
@@ -49,7 +49,7 @@ final class TaxonDocumentFactory implements TaxonDocumentFactoryInterface
 
         $taxonDocument->setDescription($taxonTranslation->getDescription());
 
-        /** @var ImageDocument[] $images */
+        /** @var ImageDocumentInterface[] $images */
         $images = [];
         foreach ($taxon->getImages() as $image) {
             $images[] = $this->imageDocumentFactory->create($image);

--- a/src/Factory/Document/TaxonDocumentFactoryInterface.php
+++ b/src/Factory/Document/TaxonDocumentFactoryInterface.php
@@ -7,8 +7,9 @@ namespace Sylius\ElasticSearchPlugin\Factory\Document;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\ElasticSearchPlugin\Document\TaxonDocument;
+use Sylius\ElasticSearchPlugin\Document\TaxonDocumentInterface;
 
 interface TaxonDocumentFactoryInterface
 {
-    public function create(TaxonInterface $taxon, LocaleInterface $localeCode, ?int $position = null): TaxonDocument;
+    public function create(TaxonInterface $taxon, LocaleInterface $localeCode, ?int $position = null): TaxonDocumentInterface;
 }

--- a/src/Factory/Document/VariantDocumentFactory.php
+++ b/src/Factory/Document/VariantDocumentFactory.php
@@ -10,8 +10,8 @@ use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Product\Model\ProductVariantTranslationInterface;
-use Sylius\ElasticSearchPlugin\Document\ImageDocument;
-use Sylius\ElasticSearchPlugin\Document\VariantDocument;
+use Sylius\ElasticSearchPlugin\Document\ImageDocumentInterface;
+use Sylius\ElasticSearchPlugin\Document\VariantDocumentInterface;
 
 final class VariantDocumentFactory implements VariantDocumentFactoryInterface
 {
@@ -43,7 +43,7 @@ final class VariantDocumentFactory implements VariantDocumentFactoryInterface
         ProductVariantInterface $productVariant,
         ChannelInterface $channel,
         LocaleInterface $locale
-    ): VariantDocument {
+    ): VariantDocumentInterface {
         $options = [];
         foreach ($productVariant->getOptionValues() as $optionValue) {
             $options[] = $this->optionDocumentFactory->create($optionValue, $locale);
@@ -60,7 +60,7 @@ final class VariantDocumentFactory implements VariantDocumentFactoryInterface
         /** @var ProductVariantTranslationInterface $productVariantTranslation */
         $productVariantTranslation = $productVariant->getTranslation($locale->getCode());
 
-        /** @var VariantDocument $variant */
+        /** @var VariantDocumentInterface $variant */
         $variant = new $this->variantDocumentClass();
         $variant->setId($productVariant->getId());
         $variant->setCode($productVariant->getCode());
@@ -76,7 +76,7 @@ final class VariantDocumentFactory implements VariantDocumentFactoryInterface
         $variant->setIsTracked($productVariant->isTracked());
         $variant->setOptions(new ArrayCollection($options));
         if ($productVariant->getImages()->count() > 0) {
-            /** @var ImageDocument[] $images */
+            /** @var ImageDocumentInterface[] $images */
             $images = [];
             foreach ($productVariant->getImages() as $image) {
                 $images[] = $this->imageDocumentFactory->create($image);

--- a/src/Factory/Document/VariantDocumentFactory.php
+++ b/src/Factory/Document/VariantDocumentFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\ElasticSearchPlugin\Factory\Document;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -74,14 +74,14 @@ final class VariantDocumentFactory implements VariantDocumentFactoryInterface
         $variant->setPrice($price);
         $variant->setStock($productVariant->getOnHand() - $productVariant->getOnHold());
         $variant->setIsTracked($productVariant->isTracked());
-        $variant->setOptions(new Collection($options));
+        $variant->setOptions(new ArrayCollection($options));
         if ($productVariant->getImages()->count() > 0) {
             /** @var ImageDocument[] $images */
             $images = [];
             foreach ($productVariant->getImages() as $image) {
                 $images[] = $this->imageDocumentFactory->create($image);
             }
-            $variant->setImages(new Collection($images));
+            $variant->setImages(new ArrayCollection($images));
         }
 
         return $variant;

--- a/src/Factory/Document/VariantDocumentFactoryInterface.php
+++ b/src/Factory/Document/VariantDocumentFactoryInterface.php
@@ -7,7 +7,7 @@ namespace Sylius\ElasticSearchPlugin\Factory\Document;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
-use Sylius\ElasticSearchPlugin\Document\VariantDocument;
+use Sylius\ElasticSearchPlugin\Document\VariantDocumentInterface;
 
 interface VariantDocumentFactoryInterface
 {
@@ -15,5 +15,5 @@ interface VariantDocumentFactoryInterface
         ProductVariantInterface $productVariant,
         ChannelInterface $channel,
         LocaleInterface $locale
-    ): VariantDocument;
+    ): VariantDocumentInterface;
 }

--- a/src/Factory/View/ProductListViewFactory.php
+++ b/src/Factory/View/ProductListViewFactory.php
@@ -14,11 +14,11 @@ use Sylius\ElasticSearchPlugin\Controller\ProductView;
 use Sylius\ElasticSearchPlugin\Controller\TaxonView;
 use Sylius\ElasticSearchPlugin\Controller\VariantView;
 use Sylius\ElasticSearchPlugin\Document\AttributeDocument;
-use Sylius\ElasticSearchPlugin\Document\ImageDocument;
-use Sylius\ElasticSearchPlugin\Document\PriceDocument;
-use Sylius\ElasticSearchPlugin\Document\ProductDocument;
-use Sylius\ElasticSearchPlugin\Document\TaxonDocument;
-use Sylius\ElasticSearchPlugin\Document\VariantDocument;
+use Sylius\ElasticSearchPlugin\Document\ImageDocumentInterface;
+use Sylius\ElasticSearchPlugin\Document\PriceDocumentInterface;
+use Sylius\ElasticSearchPlugin\Document\ProductDocumentInterface;
+use Sylius\ElasticSearchPlugin\Document\TaxonDocumentInterface;
+use Sylius\ElasticSearchPlugin\Document\VariantDocumentInterface;
 
 final class ProductListViewFactory implements ProductListViewFactoryInterface
 {
@@ -79,7 +79,7 @@ final class ProductListViewFactory implements ProductListViewFactoryInterface
         $productListView->pages = $pager['num_pages'];
         $productListView->limit = $pager['limit'];
 
-        /** @var ProductDocument $product */
+        /** @var ProductDocumentInterface $product */
         foreach ($result as $product) {
             $productListView->items[] = $this->getProductView($product);
         }
@@ -88,7 +88,7 @@ final class ProductListViewFactory implements ProductListViewFactoryInterface
     }
 
     /**
-     * @param Collection|ImageDocument[] $images
+     * @param Collection|ImageDocumentInterface[] $images
      *
      * @return ImageView[]
      */
@@ -108,12 +108,12 @@ final class ProductListViewFactory implements ProductListViewFactoryInterface
     }
 
     /**
-     * @param Collection|TaxonDocument[] $taxons
-     * @param TaxonDocument|null $mainTaxonDocument
+     * @param Collection|TaxonDocumentInterface[] $taxons
+     * @param TaxonDocumentInterface|null $mainTaxonDocument
      *
      * @return TaxonView
      */
-    private function getTaxonView(Collection $taxons, ?TaxonDocument $mainTaxonDocument): TaxonView
+    private function getTaxonView(Collection $taxons, ?TaxonDocumentInterface $mainTaxonDocument): TaxonView
     {
         /** @var TaxonView $taxonView */
         $taxonView = new $this->taxonViewClass();
@@ -148,11 +148,11 @@ final class ProductListViewFactory implements ProductListViewFactoryInterface
     }
 
     /**
-     * @param PriceDocument $price
+     * @param PriceDocumentInterface $price
      *
      * @return PriceView
      */
-    private function getPriceView(PriceDocument $price): PriceView
+    private function getPriceView(PriceDocumentInterface $price): PriceView
     {
         /** @var PriceView $priceView */
         $priceView = new $this->priceViewClass();
@@ -164,7 +164,7 @@ final class ProductListViewFactory implements ProductListViewFactoryInterface
     }
 
     /**
-     * @param VariantDocument[]|Collection $variants
+     * @param VariantDocumentInterface[]|Collection $variants
      *
      * @return array
      */
@@ -191,11 +191,11 @@ final class ProductListViewFactory implements ProductListViewFactoryInterface
     }
 
     /**
-     * @param ProductDocument $product
+     * @param ProductDocumentInterface $product
      *
      * @return ProductView
      */
-    private function getProductView(ProductDocument $product): ProductView
+    private function getProductView(ProductDocumentInterface $product): ProductView
     {
         /** @var ProductView $productView */
         $productView = new $this->productViewClass();

--- a/src/Factory/View/ProductListViewFactory.php
+++ b/src/Factory/View/ProductListViewFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\ElasticSearchPlugin\Factory\View;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\Collection;
 use ONGR\FilterManagerBundle\Search\SearchResponse;
 use Sylius\ElasticSearchPlugin\Controller\AttributeView;
 use Sylius\ElasticSearchPlugin\Controller\ImageView;

--- a/src/Projection/ProductProjector.php
+++ b/src/Projection/ProductProjector.php
@@ -10,7 +10,7 @@ use ONGR\ElasticsearchBundle\Service\Repository;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
-use Sylius\ElasticSearchPlugin\Document\ProductDocument;
+use Sylius\ElasticSearchPlugin\Document\ProductDocumentInterface;
 use Sylius\ElasticSearchPlugin\Event\ProductCreated;
 use Sylius\ElasticSearchPlugin\Event\ProductDeleted;
 use Sylius\ElasticSearchPlugin\Event\ProductUpdated;
@@ -36,13 +36,15 @@ final class ProductProjector
     /**
      * @param Manager $elasticsearchManager
      * @param ProductDocumentFactoryInterface $productDocumentFactory
+     * @param string $productDocumentClass
      */
     public function __construct(
         Manager $elasticsearchManager,
-        ProductDocumentFactoryInterface $productDocumentFactory
+        ProductDocumentFactoryInterface $productDocumentFactory,
+        string $productDocumentClass
     ) {
         $this->elasticsearchManager = $elasticsearchManager;
-        $this->productDocumentRepository = $elasticsearchManager->getRepository(ProductDocument::class);
+        $this->productDocumentRepository = $elasticsearchManager->getRepository($productDocumentClass);
         $this->productDocumentFactory = $productDocumentFactory;
     }
 
@@ -107,7 +109,7 @@ final class ProductProjector
 
     private function scheduleRemovingOldProductDocuments(ProductInterface $product): void
     {
-        /** @var DocumentIterator|ProductDocument[] $currentProductDocuments */
+        /** @var DocumentIterator|ProductDocumentInterface[] $currentProductDocuments */
         $currentProductDocuments = $this->productDocumentRepository->findBy(['code' => $product->getCode()]);
 
         foreach ($currentProductDocuments as $sameCodeProductDocument) {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -18,6 +18,7 @@
         <service id="sylius_elastic_search.projector.product" class="Sylius\ElasticSearchPlugin\Projection\ProductProjector">
             <argument type="service" id="es.manager.default" />
             <argument type="service" id="sylius_elastic_search.factory.product" />
+            <argument>%sylius_elastic_search.document.product.class%</argument>
             <tag name="event_subscriber" subscribes_to="Sylius\ElasticSearchPlugin\Event\ProductCreated" method="handleProductCreated" />
             <tag name="event_subscriber" subscribes_to="Sylius\ElasticSearchPlugin\Event\ProductUpdated" method="handleProductUpdated" />
             <tag name="event_subscriber" subscribes_to="Sylius\ElasticSearchPlugin\Event\ProductDeleted" method="handleProductDeleted" />

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -13,6 +13,7 @@
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="es.manager.default" />
             <argument type="service" id="sylius_elastic_search.factory.product" />
+            <argument>%sylius_elastic_search.document.product.class%</argument>
             <tag name="console.command" />
         </service>
     </services>

--- a/tests/Factory/ProductDocumentFactoryTest.php
+++ b/tests/Factory/ProductDocumentFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\ElasticSearchPlugin\Factory;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Bundle\ChannelBundle\Doctrine\ORM\ChannelRepository;
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\ProductRepository;
 use Sylius\Component\Core\Model\Channel;
@@ -106,7 +106,7 @@ final class ProductDocumentFactoryTest extends KernelTestCase
         $this->assertEquals($product->getCode(), $product->getCode());
         $this->assertEquals($product->getName(), $product->getName());
         $this->assertEquals('en_GB', $product->getLocaleCode());
-        $this->assertEquals(new Collection($productAttributes), $product->getAttributes());
+        $this->assertEquals(new ArrayCollection($productAttributes), $product->getAttributes());
         $this->assertEquals(1000, $product->getPrice()->getAmount());
         $this->assertEquals('GBP', $product->getPrice()->getCurrency());
         $this->assertEquals('en_GB', $product->getLocaleCode());
@@ -115,8 +115,8 @@ final class ProductDocumentFactoryTest extends KernelTestCase
         $this->assertEquals('Logan Mug', $product->getName());
         $this->assertEquals($createdAt, $product->getCreatedAt());
         $this->assertEquals('Logan Mug', $product->getDescription());
-        $this->assertEquals($taxon, $product->getMainTaxon());
-        $this->assertEquals(new Collection($productTaxons), $product->getTaxons());
+        $this->assertEquals($taxon->getCode(), $product->getMainTaxon()->getCode());
+        $this->assertEquals(new ArrayCollection($productTaxons), $product->getTaxons());
         $this->assertEquals(0.0, $product->getAverageReviewRating());
     }
 
@@ -170,7 +170,7 @@ final class ProductDocumentFactoryTest extends KernelTestCase
         $this->assertEquals($product->getName(), $product->getName());
         $this->assertEquals('en_GB', $product->getLocaleCode());
         $this->assertEquals(
-            new Collection([$productAttribute]),
+            new ArrayCollection([$productAttribute]),
             $product->getAttributes()
         );
         $this->assertEquals(1000, $product->getPrice()->getAmount());
@@ -182,7 +182,7 @@ final class ProductDocumentFactoryTest extends KernelTestCase
         $this->assertEquals($createdAt, $product->getCreatedAt());
         $this->assertEquals('Logan Mug', $product->getDescription());
         $this->assertEquals($taxon, $product->getMainTaxon());
-        $this->assertEquals(new Collection($productTaxons), $product->getTaxons());
+        $this->assertEquals(new ArrayCollection($productTaxons), $product->getTaxons());
         $this->assertEquals(0.0, $product->getAverageReviewRating());
     }
 


### PR DESCRIPTION
I've took some closer look on the case of collection type hinting. Firstly, the setter is mandatory, so sorry for my previous comment, secondly ONGR collection class is deprecated and not recommended anymore, in stead I changed the type hinting to use `Doctrine\Common\Collections\Collection` interface, because this includes both `Doctrine\Common\Collections\ArrayCollection` that is recommended by the ONGR collection deprecation message (see here: https://github.com/ongr-io/ElasticsearchBundle/blob/a2642ee9549f3906f2d22d88479364ccc1a542f9/Collection/Collection.php#L19) and `ONGR\ElasticsearchBundle\Result\ObjectIterator` that ONGR ES bundle uses when lazy loading the results after search. 
However, this is a potential place to pay close attention to in the future, because I contacted the maintainer of the ONGR project and I was informed that this is a known issue in ONGR ES bundle and will be attended to in the comming months.

Closes #95 